### PR TITLE
Add external references option under templates menu

### DIFF
--- a/references.html
+++ b/references.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<html class="no-js dgm-site">
+    <head>
+        <meta charset="utf-8">
+        <title>Guía de Datos Abiertos para México | Referencias Externas</title>
+        <meta name="description" content="">
+        <meta name="viewport" content="width=device-width">
+
+        <link rel="shortcut icon" href="img/favicon.ico">
+        <link rel="stylesheet" href="styles/main.css">
+    </head>
+    <body>
+        <div class="site-header">
+            <header class="site-header-bottom" role="banner" aria-label="Encabezado del sitio">
+                <div class="main-container">
+                    <div class="cols-12">
+                        <div class="col col-12">
+                            <div class="col-inner">
+                                <a class="site-brand" href="http://datos.gob.mx/" title="Ir a la página de inicio de DATOS.GOB.MX">
+                                    <img src="http://datos.gob.mx/assets/svg/logo-dgm-white.svg" alt="DATOS.GOB.MX" role="presentation">
+                                </a>
+                                <div class="nav-burguer" aria-hidden="true"><span></span></div>
+                                <ul class="site-navigation" aria-label="Navegación principal" role="navigation">
+                                    <li>
+                                        <a class="page-link" href="http://datos.gob.mx/catalogo" title="Ir al conjunto de datos" aria-label="Ir al catalogo de datos">Datos</a>
+                                    </li>
+                                    <li>
+                                        <a class="page-link" href="http://datos.gob.mx/historias/">Historias</a>
+                                    </li>
+                                    <li>
+                                        <a class="page-link" href="http://datos.gob.mx/apps/">Apps</a>
+                                    </li>
+                                    <li>
+                                        <a class="page-link" href="http://datos.gob.mx/herramientas/">Herramientas</a>
+                                    </li>
+                                    <li>
+                                        <a class="page-link" href="http://datos.gob.mx/avances/">Avances</a>
+                                    </li>
+                                    <li>
+                                        <a class="page-link" href="http://datos.gob.mx/acerca/">Acerca</a>
+                                    </li>
+                                    <li>
+                                        <a class="page-link" href="http://datos.gob.mx/guia">Guía</a>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </header>
+        </div>
+        <main id="main-content" tabindex="-1" role="main" aria-label="Contenido principal">
+            <div class="main-container">
+                <div id="title-section" class="cols-12">
+                    <div class="col col-2">
+                        <div class="col-inner">
+                            <h1 role="presentation"><a href="index.html" class="info-title" tabindex="-1">Guía</a></h1>
+                        </div>
+                    </div>
+                    <div class="col col-10 breadcrumb">
+                        <div class="col-inner">
+                            <p><a href="index.html">/</a>  <a href="templates.html">Manuales y Plantillas</a>  <a href="#">/</a>  <a href="references.html">Referencias Externas</a></p>  </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="cols-12">
+                    <div class="col col-2">
+                        <div class="col-inner">
+                            <p class="intro-text">4 pasos básicos para cumplir con el Decreto de Datos Abiertos.</p>
+                            <aside class="guide-navigation">
+                                <ul>
+                                    <li class="item-intro"><a href="intro.html">Introducción</a></li>
+                                    <li class="item-plan"><a href="plan">1. Planea</a></li>
+                                    <li class="item-publish"><a href="publish">2. Publica</a></li>
+                                    <li class="item-perfect"><a href="perfect">3. Perfecciona</a></li>
+                                    <li class="item-promote"><a href="promote">4. Promueve</a></li>
+                                    <li class="item-templates active"><a href="templates.html">Manuales y Plantillas</a></li>
+                                </ul>
+                            </aside>
+                        </div>
+                    </div>
+                    <div class="col col-10">
+                        <div class="col-inner">
+                            <h3>Índice de Referencias Externas</h3>
+                            <div class="intro section-content">
+                                <ul>
+                                    <li><a href="http://translate.google.com/translate?hl=en&ie=UTF8&prev=_t&sl=en&tl=es&u=http://www.w3.org/TR/vocab-dcat/&sandbox=0&usg=ALkJrhjqpZ0_Yvk24KCXddzyMbxjaVdNxg" target="_blank">http://www.w3.org/TR/vocab-dcat/</a></li>
+                                    <li><a href="http://www.inegi.org.mx/geo/contenidos/geoestadistica/default.aspx" target="_blank">http://www.inegi.org.mx/geo/contenidos/geoestadistica/default.aspx</a></li>
+                                    <li><a href="http://www.coneval.gob.mx/Informes/Pobreza/Datos_abiertos/Indicadores_municipales_sabana_DIC.txt" target="_blank">http://www.coneval.gob.mx/Informes/Pobreza/Datos_abiertos/Indicadores_municipales_sabana_DIC.txt</a></li>
+                                    <li><a href="https://github.com/mxabierto/adela/wiki/Gu%C3%ADa-de-uso-para-el-funcionario" target="_blank">https://github.com/mxabierto/adela/wiki/Gu%C3%ADa-de-uso-para-el-funcionario</a></li>
+                                    <li><a href="http://datos.gob.mx/libreusomx/" target="_blank">http://datos.gob.mx/libreusomx/</a></li>
+                                    <li><a href="http://www.geonames.org/4017700/baja-california.html" target="_blank">http://www.geonames.org/4017700/baja-california.html</a></li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </main>
+    </body>
+</html>

--- a/templates.html
+++ b/templates.html
@@ -138,6 +138,16 @@
                                     <a href="docs/glosario.docx" class="btn btn-download">Descargar Archivo</a>
                                 </div>
                             </div>
+                            <div class="col col-4 resource-item">
+                                <div class="col-inner">
+                                    <div class="item">
+                                        <p>Referencias Externas</p>
+                                        <div class="item-hover">
+                                            <p><a href="references.html">Consulta el índice de referencias que menciona la Guía.</a></p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
closes #31 

### TODO
- [x] Add new option ( "Referencias Externas" ) under "Manuales y Plantillas" menu
- [x] Add new page that shows a list of links mentioned at the document

### HOW TO TEST

* Go to "Manuales y Plantillas" menu and click on "Referencias Externas"
* You should see something like this

![external references](https://cloud.githubusercontent.com/assets/2633527/8313267/485c9604-19a7-11e5-8f77-f4bf43ab4dc3.png)
